### PR TITLE
fix android adjustresize and ios when used with react navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 import KeyboardAccessoryView from './lib/KeyboardAccessoryView';
 import KeyboardAccessoryNavigation from './lib/KeyboardAccessoryNavigation';
+import KeyboardAwareTabBarComponent from './lib/KeyboardAwareTabBarComponent';
 
 export {
   KeyboardAccessoryView,
   KeyboardAccessoryNavigation,
+  KeyboardAwareTabBarComponent
 }

--- a/lib/KeyboardAccessoryView.js
+++ b/lib/KeyboardAccessoryView.js
@@ -2,159 +2,184 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  View,
-  Keyboard,
-  LayoutAnimation,
-  Platform,
-  StyleSheet,
+    View,
+    Keyboard,
+    LayoutAnimation,
+    Platform,
+    StyleSheet,
 } from 'react-native';
 
 const accessoryAnimation = (duration, easing, animationConfig = null) => {
 
-  if (animationConfig) {
-    if (typeof animationConfig === 'function') {
-      return animationConfig(duration, easing);
+    if (animationConfig) {
+        if (typeof animationConfig === 'function') {
+            return animationConfig(duration, easing);
+        }
+        return animationConfig;
     }
-    return animationConfig;
-  }
 
-  if (Platform.OS === 'android') {
-    return {
-       duration: 200,
-       create: {
-         duration: 200,
-         type: LayoutAnimation.Types.linear,
-         property: LayoutAnimation.Properties.opacity
-       },
-       update: {
-         type: LayoutAnimation.Types.linear,
-       }
-     }
-  }
+    if (Platform.OS === 'android') {
+        return {
+            duration: 200,
+            create: {
+                duration: 200,
+                type: LayoutAnimation.Types.linear,
+                property: LayoutAnimation.Properties.opacity
+            },
+            update: {
+                type: LayoutAnimation.Types.linear,
+            }
+        }
+    }
 
-  return LayoutAnimation.create(
-    duration,
-    LayoutAnimation.Types[easing],
-    LayoutAnimation.Properties.opacity,
-  )
+    return LayoutAnimation.create(
+        duration,
+        LayoutAnimation.Types[easing],
+        LayoutAnimation.Properties.opacity,
+    )
 }
 
 class KeyboardAccessoryView extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.state = {
-      keyboardHeight: 0,
-      accessoryHeight: 50,
-      isKeyboardVisible: false,
+        this.state = {
+            keyboardHeight: 0,
+            accessoryHeight: 50,
+            isKeyboardVisible: false,
+        }
+
+        this.handleKeyboardShow = this.handleKeyboardShow.bind(this);
+        this.handleKeyboardHide= this.handleKeyboardHide.bind(this);
     }
 
-    this.handleKeyboardShow = this.handleKeyboardShow.bind(this);
-    this.handleKeyboardHide= this.handleKeyboardHide.bind(this);
-  }
+    componentWillMount () {
+        const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+        const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-  componentWillMount () {
-    const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-    const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
-
-    this.keyboardShowEventListener = Keyboard.addListener(keyboardShowEvent, this.handleKeyboardShow);
-    this.keyboardHideEventListener = Keyboard.addListener(keyboardHideEvent, this.handleKeyboardHide);
-  }
-
-  componentWillUnmount() {
-    this.keyboardShowEventListener.remove();
-    this.keyboardHideEventListener.remove();
-  }
-
-  handleChildrenLayout(layoutEvent) {
-    this.setState({
-      accessoryHeight: layoutEvent.nativeEvent.layout.height,
-    });
-  }
-
-  handleKeyboardShow(keyboardEvent) {
-    if (!keyboardEvent.endCoordinates) {
-      return;
+        this.keyboardShowEventListener = Keyboard.addListener(keyboardShowEvent, this.handleKeyboardShow);
+        this.keyboardHideEventListener = Keyboard.addListener(keyboardHideEvent, this.handleKeyboardHide);
     }
 
-    const { animationConfig, animateOn } = this.props;
-
-    if (animateOn === 'all' || Platform.OS === animateOn) {
-      LayoutAnimation.configureNext(
-        accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
-      );
+    componentWillUnmount() {
+        this.keyboardShowEventListener.remove();
+        this.keyboardHideEventListener.remove();
     }
 
-    this.setState({
-      isKeyboardVisible: true,
-      keyboardHeight: keyboardEvent.endCoordinates.height,
-    })
-  }
-
-  handleKeyboardHide(keyboardEvent) {
-    const { animateOn, animationConfig } = this.props;
-
-    if (animateOn === 'all' || Platform.OS === animateOn) {
-      LayoutAnimation.configureNext(
-        animationConfig || accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
-      );
+    handleChildrenLayout(layoutEvent) {
+        this.setState({
+            accessoryHeight: layoutEvent.nativeEvent.layout.height,
+        });
     }
 
-    this.setState({
-      isKeyboardVisible: false,
-      keyboardHeight: 0,
-    })
-  }
+    handleKeyboardShow(keyboardEvent) {
+        if (!keyboardEvent.endCoordinates) {
+            return;
+        }
 
-  render() {
-    const { isKeyboardVisible , accessoryHeight, keyboardHeight } = this.state;
-    const { bumperHeight, alwaysVisible, visibleOpacity, hiddenOpacity, style } = this.props;
-    return (
-      <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight : 0) }}>
-        <View style={[styles.accessory, style, {
-          opacity: (isKeyboardVisible || alwaysVisible ? visibleOpacity : hiddenOpacity),
-          bottom: keyboardHeight - bumperHeight,
-          height: accessoryHeight + bumperHeight,
-        }]}>
-          <View onLayout={this.handleChildrenLayout.bind(this)}>
-            { this.props.children }
-          </View>
-        </View>
-      </View>
-    );
-  }
+        const keyboardHeight = Platform.select({
+            ios: keyboardEvent.endCoordinates.height,
+            android: this.props.androidWindowSoftInputAdjustResize
+              ? this.props.bumperHeight
+              : keyboardEvent.endCoordinates.height
+        });
+
+        const keyboardAnimate = () => {
+            const { animationConfig, animateOn } = this.props;
+
+            if (animateOn === 'all' || Platform.OS === animateOn) {
+                LayoutAnimation.configureNext(
+                    accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
+                );
+            }
+
+            this.setState({
+                isKeyboardVisible: true,
+                keyboardHeight: keyboardHeight
+            })
+        };
+
+        if (Platform.OS === 'ios' || typeof this.props.onKeyboardShowDelay !== 'number') {
+            keyboardAnimate();
+        } else {
+            setTimeout(() => {
+                keyboardAnimate()
+            }, this.props.onKeyboardShowDelay);
+        }
+    }
+
+    handleKeyboardHide(keyboardEvent) {
+        const { animateOn, animationConfig } = this.props;
+
+        if (animateOn === 'all' || Platform.OS === animateOn) {
+            LayoutAnimation.configureNext(
+                animationConfig || accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
+            );
+        }
+
+        this.setState({
+            isKeyboardVisible: false,
+            keyboardHeight: 0,
+        })
+    }
+
+    render() {
+
+        const { isKeyboardVisible , accessoryHeight, keyboardHeight } = this.state;
+        const { bumperHeight, alwaysVisible, visibleOpacity, hiddenOpacity, style } = this.props;
+
+        return (
+            <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight : 0) }}>
+                <View style={[styles.accessory, style, {
+                    opacity: (isKeyboardVisible || alwaysVisible ? visibleOpacity : hiddenOpacity),
+                    bottom: keyboardHeight - bumperHeight,
+                    height: accessoryHeight + bumperHeight,
+                }]}>
+                    <View onLayout={this.handleChildrenLayout.bind(this)}>
+                        { this.props.children }
+                    </View>
+                </View>
+            </View>
+        );
+    }
 }
 
 KeyboardAccessoryView.propTypes = {
-  style: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.number
-  ]),
-  animateOn: PropTypes.oneOf(['ios', 'android', 'all', 'none']),
-  animationConfig: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.func
-  ]),
-  alwaysVisible: PropTypes.bool,
-  bumperHeight: PropTypes.number,
-  visibleOpacity: PropTypes.number,
-  hiddenOpacity: PropTypes.number,
+    style: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.number
+    ]),
+    animateOn: PropTypes.oneOf(['ios', 'android', 'all', 'none']),
+    animationConfig: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.func
+    ]),
+    alwaysVisible: PropTypes.bool,
+    bumperHeight: PropTypes.number,
+    visibleOpacity: PropTypes.number,
+    hiddenOpacity: PropTypes.number,
+    onKeyboardShowDelay: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.bool
+    ]),
+    androidWindowSoftInputAdjustResize: PropTypes.bool
 }
 
 KeyboardAccessoryView.defaultProps = {
-  animateOn: 'ios',
-  bumperHeight: 15,
-  visibleOpacity: 1,
-  hiddenOpacity: 0
+    animateOn: 'ios',
+    bumperHeight: 15,
+    visibleOpacity: 1,
+    hiddenOpacity: 0,
+    androidWindowSoftInputAdjustResize: false
 }
 
 const styles = StyleSheet.create({
-  accessory: {
-    position: 'absolute',
-    right: 0,
-    left: 0,
-    backgroundColor: '#EFF0F1'
-  }
+    accessory: {
+        position: 'absolute',
+        right: 0,
+        left: 0,
+        backgroundColor: '#EFF0F1'
+    }
 })
 
 export default KeyboardAccessoryView;

--- a/lib/KeyboardAccessoryView.js
+++ b/lib/KeyboardAccessoryView.js
@@ -2,184 +2,184 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-    View,
-    Keyboard,
-    LayoutAnimation,
-    Platform,
-    StyleSheet,
+  View,
+  Keyboard,
+  LayoutAnimation,
+  Platform,
+  StyleSheet,
 } from 'react-native';
 
 const accessoryAnimation = (duration, easing, animationConfig = null) => {
 
-    if (animationConfig) {
-        if (typeof animationConfig === 'function') {
-            return animationConfig(duration, easing);
-        }
-        return animationConfig;
+  if (animationConfig) {
+    if (typeof animationConfig === 'function') {
+      return animationConfig(duration, easing);
     }
+    return animationConfig;
+  }
 
-    if (Platform.OS === 'android') {
-        return {
-            duration: 200,
-            create: {
-                duration: 200,
-                type: LayoutAnimation.Types.linear,
-                property: LayoutAnimation.Properties.opacity
-            },
-            update: {
-                type: LayoutAnimation.Types.linear,
-            }
-        }
+  if (Platform.OS === 'android') {
+    return {
+      duration: 200,
+      create: {
+        duration: 200,
+        type: LayoutAnimation.Types.linear,
+        property: LayoutAnimation.Properties.opacity
+      },
+      update: {
+        type: LayoutAnimation.Types.linear,
+      }
     }
+  }
 
-    return LayoutAnimation.create(
-        duration,
-        LayoutAnimation.Types[easing],
-        LayoutAnimation.Properties.opacity,
-    )
+  return LayoutAnimation.create(
+    duration,
+    LayoutAnimation.Types[easing],
+    LayoutAnimation.Properties.opacity,
+  )
 }
 
 class KeyboardAccessoryView extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            keyboardHeight: 0,
-            accessoryHeight: 50,
-            isKeyboardVisible: false,
-        }
-
-        this.handleKeyboardShow = this.handleKeyboardShow.bind(this);
-        this.handleKeyboardHide= this.handleKeyboardHide.bind(this);
+    this.state = {
+      keyboardHeight: 0,
+      accessoryHeight: 50,
+      isKeyboardVisible: false,
     }
 
-    componentWillMount () {
-        const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-        const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    this.handleKeyboardShow = this.handleKeyboardShow.bind(this);
+    this.handleKeyboardHide= this.handleKeyboardHide.bind(this);
+  }
 
-        this.keyboardShowEventListener = Keyboard.addListener(keyboardShowEvent, this.handleKeyboardShow);
-        this.keyboardHideEventListener = Keyboard.addListener(keyboardHideEvent, this.handleKeyboardHide);
+  componentWillMount () {
+    const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    this.keyboardShowEventListener = Keyboard.addListener(keyboardShowEvent, this.handleKeyboardShow);
+    this.keyboardHideEventListener = Keyboard.addListener(keyboardHideEvent, this.handleKeyboardHide);
+  }
+
+  componentWillUnmount() {
+    this.keyboardShowEventListener.remove();
+    this.keyboardHideEventListener.remove();
+  }
+
+  handleChildrenLayout(layoutEvent) {
+    this.setState({
+      accessoryHeight: layoutEvent.nativeEvent.layout.height,
+    });
+  }
+
+  handleKeyboardShow(keyboardEvent) {
+    if (!keyboardEvent.endCoordinates) {
+      return;
     }
 
-    componentWillUnmount() {
-        this.keyboardShowEventListener.remove();
-        this.keyboardHideEventListener.remove();
-    }
+    const keyboardHeight = Platform.select({
+      ios: keyboardEvent.endCoordinates.height,
+      android: this.props.androidWindowSoftInputAdjustResize
+        ? this.props.bumperHeight
+        : keyboardEvent.endCoordinates.height
+    });
 
-    handleChildrenLayout(layoutEvent) {
-        this.setState({
-            accessoryHeight: layoutEvent.nativeEvent.layout.height,
-        });
-    }
+    const keyboardAnimate = () => {
+      const { animationConfig, animateOn } = this.props;
 
-    handleKeyboardShow(keyboardEvent) {
-        if (!keyboardEvent.endCoordinates) {
-            return;
-        }
-
-        const keyboardHeight = Platform.select({
-            ios: keyboardEvent.endCoordinates.height,
-            android: this.props.androidWindowSoftInputAdjustResize
-              ? this.props.bumperHeight
-              : keyboardEvent.endCoordinates.height
-        });
-
-        const keyboardAnimate = () => {
-            const { animationConfig, animateOn } = this.props;
-
-            if (animateOn === 'all' || Platform.OS === animateOn) {
-                LayoutAnimation.configureNext(
-                    accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
-                );
-            }
-
-            this.setState({
-                isKeyboardVisible: true,
-                keyboardHeight: keyboardHeight
-            })
-        };
-
-        if (Platform.OS === 'ios' || typeof this.props.onKeyboardShowDelay !== 'number') {
-            keyboardAnimate();
-        } else {
-            setTimeout(() => {
-                keyboardAnimate()
-            }, this.props.onKeyboardShowDelay);
-        }
-    }
-
-    handleKeyboardHide(keyboardEvent) {
-        const { animateOn, animationConfig } = this.props;
-
-        if (animateOn === 'all' || Platform.OS === animateOn) {
-            LayoutAnimation.configureNext(
-                animationConfig || accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
-            );
-        }
-
-        this.setState({
-            isKeyboardVisible: false,
-            keyboardHeight: 0,
-        })
-    }
-
-    render() {
-
-        const { isKeyboardVisible , accessoryHeight, keyboardHeight } = this.state;
-        const { bumperHeight, alwaysVisible, visibleOpacity, hiddenOpacity, style } = this.props;
-
-        return (
-            <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight : 0) }}>
-                <View style={[styles.accessory, style, {
-                    opacity: (isKeyboardVisible || alwaysVisible ? visibleOpacity : hiddenOpacity),
-                    bottom: keyboardHeight - bumperHeight,
-                    height: accessoryHeight + bumperHeight,
-                }]}>
-                    <View onLayout={this.handleChildrenLayout.bind(this)}>
-                        { this.props.children }
-                    </View>
-                </View>
-            </View>
+      if (animateOn === 'all' || Platform.OS === animateOn) {
+        LayoutAnimation.configureNext(
+          accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
         );
+      }
+
+      this.setState({
+        isKeyboardVisible: true,
+        keyboardHeight: keyboardHeight
+      })
+    };
+
+    if (Platform.OS === 'ios' || typeof this.props.onKeyboardShowDelay !== 'number') {
+      keyboardAnimate();
+    } else {
+      setTimeout(() => {
+        keyboardAnimate()
+      }, this.props.onKeyboardShowDelay);
     }
+  }
+
+  handleKeyboardHide(keyboardEvent) {
+    const { animateOn, animationConfig } = this.props;
+
+    if (animateOn === 'all' || Platform.OS === animateOn) {
+      LayoutAnimation.configureNext(
+        animationConfig || accessoryAnimation(keyboardEvent.duration, keyboardEvent.easing, animationConfig)
+      );
+    }
+
+    this.setState({
+      isKeyboardVisible: false,
+      keyboardHeight: 0,
+    })
+  }
+
+  render() {
+
+    const { isKeyboardVisible , accessoryHeight, keyboardHeight } = this.state;
+    const { bumperHeight, alwaysVisible, visibleOpacity, hiddenOpacity, style } = this.props;
+
+    return (
+      <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight : 0) }}>
+        <View style={[styles.accessory, style, {
+          opacity: (isKeyboardVisible || alwaysVisible ? visibleOpacity : hiddenOpacity),
+          bottom: keyboardHeight - bumperHeight,
+          height: accessoryHeight + bumperHeight,
+        }]}>
+          <View onLayout={this.handleChildrenLayout.bind(this)}>
+            { this.props.children }
+          </View>
+        </View>
+      </View>
+    );
+  }
 }
 
 KeyboardAccessoryView.propTypes = {
-    style: PropTypes.oneOfType([
-        PropTypes.object,
-        PropTypes.number
-    ]),
-    animateOn: PropTypes.oneOf(['ios', 'android', 'all', 'none']),
-    animationConfig: PropTypes.oneOfType([
-        PropTypes.object,
-        PropTypes.func
-    ]),
-    alwaysVisible: PropTypes.bool,
-    bumperHeight: PropTypes.number,
-    visibleOpacity: PropTypes.number,
-    hiddenOpacity: PropTypes.number,
-    onKeyboardShowDelay: PropTypes.oneOfType([
-        PropTypes.number,
-        PropTypes.bool
-    ]),
-    androidWindowSoftInputAdjustResize: PropTypes.bool
+  style: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]),
+  animateOn: PropTypes.oneOf(['ios', 'android', 'all', 'none']),
+  animationConfig: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.func
+  ]),
+  alwaysVisible: PropTypes.bool,
+  bumperHeight: PropTypes.number,
+  visibleOpacity: PropTypes.number,
+  hiddenOpacity: PropTypes.number,
+  onKeyboardShowDelay: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool
+  ]),
+  androidWindowSoftInputAdjustResize: PropTypes.bool
 }
 
 KeyboardAccessoryView.defaultProps = {
-    animateOn: 'ios',
-    bumperHeight: 15,
-    visibleOpacity: 1,
-    hiddenOpacity: 0,
-    androidWindowSoftInputAdjustResize: false
+  animateOn: 'ios',
+  bumperHeight: 15,
+  visibleOpacity: 1,
+  hiddenOpacity: 0,
+  androidWindowSoftInputAdjustResize: false
 }
 
 const styles = StyleSheet.create({
-    accessory: {
-        position: 'absolute',
-        right: 0,
-        left: 0,
-        backgroundColor: '#EFF0F1'
-    }
+  accessory: {
+    position: 'absolute',
+    right: 0,
+    left: 0,
+    backgroundColor: '#EFF0F1'
+  }
 })
 
 export default KeyboardAccessoryView;

--- a/lib/KeyboardAwareTabBarComponent.js
+++ b/lib/KeyboardAwareTabBarComponent.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import PropTypes from 'prop-types';
+import { Keyboard, Platform } from 'react-native'
+import { TabBarBottom } from 'react-navigation'
+
+export default class KeyboardAwareTabBarComponent extends React.PureComponent {
+
+    constructor(props) {
+        super(props);
+
+        this.keyboardWillShow = this.keyboardWillShow.bind(this);
+        this.keyboardWillHide = this.keyboardWillHide.bind(this);
+
+        this.state = {
+            isVisible: true
+        }
+    }
+
+    componentWillMount() {
+        const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+        const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+        this.keyboardWillShowSub = Keyboard.addListener(keyboardShowEvent, this.keyboardWillShow);
+        this.keyboardWillHideSub = Keyboard.addListener(keyboardHideEvent, this.keyboardWillHide);
+    }
+
+    componentWillUnmount() {
+        this.keyboardWillShowSub.remove();
+        this.keyboardWillHideSub.remove();
+    }
+
+    keyboardWillShow(event) {
+        this.setState({
+            isVisible: false
+        })
+    }
+
+    keyboardWillHide(event) {
+        this.setState({
+            isVisible: true
+        })
+    }
+
+    render() {
+        const TabBarComponent = this.props.tabBarComponent;
+
+        return this.state.isVisible
+            ? <TabBarComponent {...this.props} />
+            : null
+    }
+}
+
+KeyboardAwareTabBarComponent.propTypes = {
+    tabBarComponent: PropTypes.func
+};
+
+KeyboardAwareTabBarComponent.defaultProps = {
+    tabBarComponent: TabBarBottom
+};
+

--- a/lib/KeyboardAwareTabBarComponent.js
+++ b/lib/KeyboardAwareTabBarComponent.js
@@ -5,56 +5,56 @@ import { TabBarBottom } from 'react-navigation'
 
 export default class KeyboardAwareTabBarComponent extends React.PureComponent {
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.keyboardWillShow = this.keyboardWillShow.bind(this);
-        this.keyboardWillHide = this.keyboardWillHide.bind(this);
+    this.keyboardWillShow = this.keyboardWillShow.bind(this);
+    this.keyboardWillHide = this.keyboardWillHide.bind(this);
 
-        this.state = {
-            isVisible: true
-        }
+    this.state = {
+      isVisible: true
     }
+  }
 
-    componentWillMount() {
-        const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-        const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+  componentWillMount() {
+    const keyboardShowEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const keyboardHideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-        this.keyboardWillShowSub = Keyboard.addListener(keyboardShowEvent, this.keyboardWillShow);
-        this.keyboardWillHideSub = Keyboard.addListener(keyboardHideEvent, this.keyboardWillHide);
-    }
+    this.keyboardWillShowSub = Keyboard.addListener(keyboardShowEvent, this.keyboardWillShow);
+    this.keyboardWillHideSub = Keyboard.addListener(keyboardHideEvent, this.keyboardWillHide);
+  }
 
-    componentWillUnmount() {
-        this.keyboardWillShowSub.remove();
-        this.keyboardWillHideSub.remove();
-    }
+  componentWillUnmount() {
+    this.keyboardWillShowSub.remove();
+    this.keyboardWillHideSub.remove();
+  }
 
-    keyboardWillShow(event) {
-        this.setState({
-            isVisible: false
-        })
-    }
+  keyboardWillShow(event) {
+    this.setState({
+      isVisible: false
+    })
+  }
 
-    keyboardWillHide(event) {
-        this.setState({
-            isVisible: true
-        })
-    }
+  keyboardWillHide(event) {
+    this.setState({
+      isVisible: true
+    })
+  }
 
-    render() {
-        const TabBarComponent = this.props.tabBarComponent;
+  render() {
+    const TabBarComponent = this.props.tabBarComponent;
 
-        return this.state.isVisible
-            ? <TabBarComponent {...this.props} />
-            : null
-    }
+    return this.state.isVisible
+      ? <TabBarComponent {...this.props} />
+      : null
+  }
 }
 
 KeyboardAwareTabBarComponent.propTypes = {
-    tabBarComponent: PropTypes.func
+  tabBarComponent: PropTypes.func
 };
 
 KeyboardAwareTabBarComponent.defaultProps = {
-    tabBarComponent: TabBarBottom
+  tabBarComponent: TabBarBottom
 };
 


### PR DESCRIPTION
- when `android:windowSoftInputMode="adjustResize"` set in android manifest, view is pushed and therefore keyboard height should not be used as bottom offset
- added tab bar component for using this accessory with react navigation (otherwise bottom tab bar will be pushed together on android - and on ios, it's not being pushed but leaving a huge space between accessory and keyboard)
- when used with react navigation, accessory placement should be slightly delayed on android

thanks by the way for your work! It's only solution that actually works for me.