### PR TITLE
Implement Props to Hide Prev/Next Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,17 @@ A React Native Keyboard Accessory (View, Navigation) Component. Sticky views on 
 ![IOS View Example](https://media.giphy.com/media/ZFh86727hAbAc/giphy.gif)  ![IOS Navigation Example](https://media.giphy.com/media/NYsR2BtQaUaQw/giphy.gif)
 
 ## Installation
-Installation can be done through ``npm``:
+
+Via npm:
 
 ```shell
 npm install react-native-keyboard-accessory --save
+```
+
+Via Yarn:
+
+```shell
+yarn add react-native-keyboard-accessory
 ```
 
 ## Usage
@@ -18,13 +25,15 @@ You can use the ``KeyboardAccessoryView`` or the ``KeyboardAccessoryNavigation``
 components.
 
 ### Keyboard Accessory View
-Import ``react-native-keyboard-accessory``
+
+Import `react-native-keyboard-accessory`
 
 ```js
 import { KeyboardAccessoryView } from 'react-native-keyboard-accessory'
 
 ```
-And use it inside your ``render()`` function:
+
+Use it inside your `render()` function:
 
 ```jsx
 <KeyboardAccessoryView>
@@ -54,28 +63,32 @@ And use it inside your ``render()`` function:
 ## API
 
 ### *KeyboardAccessoryView*
+
 | **Prop** | **Type** | **Default** | **Description** |
 |----------|----------|-------------|-----------------|
 | `style` | `object` | `null` | Style `object` or `StyleSheet` reference which will be applied to Accessory `View` |
-| `animateOn` | `enum:string` | `'ios'` | Enables show/hide animation on given platorm. Values: `['ios', 'android', 'all', 'none']`. | 
-| `animationConfig` | `function` or `object` | `null` | For passing custom animations to show/hide. If given prop is function, `duration` and `easing` parameters from `Keyboard` event will be passed to the function, function should return `LayoutAnimation` compatible animation config. Or you can directlty pass animation config object. |
+| `animateOn` | `enum:string` | `'ios'` | Enables show/hide animation on given platform. Values: `['ios', 'android', 'all', 'none']`. |
+| `animationConfig` | `function` or `object` | `null` | For passing custom animations to show/hide. If given prop is function, `duration` and `easing` parameters from `Keyboard` event will be passed to the function, function should return `LayoutAnimation` compatible animation config. Or you can directly pass animation config object. |
 | `alwaysVisible` | `boolean` | `false` | When set to `true` Accessory View will be always visible at the bottom of the screen. Good for sticky `TextInput`'s |
-| `bumperHeight` | `number` | 15 | Bumper height to prevent visiual glitches if animation couldn't keep up with the keyboard animation. |
+| `bumperHeight` | `number` | 15 | Bumper height to prevent visual glitches if animation couldn't keep up with the keyboard animation. |
 | `visibleOpacity` | `number` | 1 | Opacity of the Accessory when it is visible. *Note:* Opacity is used for hiding the accessory to prevent render delays. |
 | `hiddenOpacity` | `number` | 0 | Opacity of the Accessory when it is hidden. |
 
 ### *KeyboardAccessoryNavigation*
+
 All the `KeyboardAccessoryView` props will be passed.
 
 | **Prop** | **Type** | **Default** | **Description** |
 |----------|----------|-------------|-----------------|
 | `doneButtonTitle` | `string` | `'Done'` | Title text to show on the right Button of Navigation View |
-| `tintColor` | `string` | `'#007AFF'` | Tint color for the arrows and done button | 
-| `doneButton` | `node` | `null` | Replace default Done Button. Non-Touchable node should be provided. | 
+| `tintColor` | `string` | `'#007AFF'` | Tint color for the arrows and done button |
+| `doneButton` | `node` | `null` | Replace default Done Button. Non-Touchable node should be provided. |
 | `nextButton` | `node` | `null` | Replace default Next Button. Non-Touchable node should be provided. |
 | `previousButton` | `node` | `null` | Replace default Previous Button. Non-Touchable node should be provided. |
 | `doneDisabled` | `boolean` | false | Disables Done Button |
 | `nextDisabled` | `boolean` | false | Disables Next Button |
+| `doneHidden` | `boolean` | false | Hides Done Button |
+| `nextHidden` | `boolean` | false | Hides Next Button |
 | `previousDisabled` | `boolean` | false | Disables Previous Button |
 | `accessoryStyle` | `object` | null | Style object or StyleSheet reference which will be applied to Navigation Accessory `View`. |
 | `doneButtonStyle` | `object` | null | Style object or StyleSheet reference which will be applied to Done Button `View` |
@@ -90,4 +103,4 @@ All the `KeyboardAccessoryView` props will be passed.
 
   ## Known Issues
 
-  - Accessory doesn't follow keyboard when closed with drag gesture. 
+  - Accessory doesn't follow keyboard when closed with drag gesture.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1717,6 +1717,11 @@
       "integrity": "sha1-A1YSWdtI0EdMi9yQ9bR7Botrv7Q=",
       "dev": true
     },
+    "clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -8082,6 +8087,27 @@
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz",
       "integrity": "sha1-IWevhrvJ+WS9Rb1fN2hOW1SWXjI="
     },
+    "react-native-dismiss-keyboard": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz",
+      "integrity": "sha1-MohiQrPyMX4SHzrrmwpYXiuHm0k="
+    },
+    "react-native-drawer-layout": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-1.3.2.tgz",
+      "integrity": "sha512-fjO0scqbJUfNu2wuEpvywL7DYLXuCXJ2W/zYhWz986rdLytidbys1QGVvkaszHrb4Y7OqO96mTkgpOcP8KWevw==",
+      "requires": {
+        "react-native-dismiss-keyboard": "1.0.0"
+      }
+    },
+    "react-native-drawer-layout-polyfill": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.2.tgz",
+      "integrity": "sha512-XzPhfLDJrYHru+e8+dFwhf0FtTeAp7JXPpFYezYV6P1nTeA1Tia/kDpFT+O2DWTrBKBEI8FGhZnThrroZmHIxg==",
+      "requires": {
+        "react-native-drawer-layout": "1.3.2"
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.0.0-alpha.39",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.39.tgz",
@@ -8110,6 +8136,14 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.19.0.tgz",
       "integrity": "sha1-zpT60c82DjNctDOKaMlfeR6GkHQ="
+    },
+    "react-native-safe-area-view": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz",
+      "integrity": "sha512-SjLdW/Th0WVMhyngH4O6yC21S+O4U4AAG3QxBr7fZ2ftgjXSpKbDHAhEpxBdFwei6HsnsC2h9oYMtPpaW9nfGg==",
+      "requires": {
+        "hoist-non-react-statics": "2.5.0"
+      }
     },
     "react-native-safe-module": {
       "version": "1.2.0",
@@ -8150,6 +8184,14 @@
         "lodash": "4.17.5"
       }
     },
+    "react-native-tab-view": {
+      "version": "0.0.74",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.74.tgz",
+      "integrity": "sha512-aCrLugxt5LqdSk0pHqu/nDGZMIM3NvxVcXb464coY7ecWgem6IxQ8riO3QXPJhXZ7HaayfofBJF9w4uIWt/AoQ==",
+      "requires": {
+        "prop-types": "15.6.1"
+      }
+    },
     "react-native-vector-icons": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-4.5.0.tgz",
@@ -8158,6 +8200,30 @@
         "lodash": "4.17.5",
         "prop-types": "15.6.1",
         "yargs": "8.0.2"
+      }
+    },
+    "react-navigation": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-1.5.2.tgz",
+      "integrity": "sha512-wFAsoMnCwnaYua7TxW51gGdQ2xwbADkVijXM0eeBHGcoB3II7QWXAJ9f0kRGK/Cgxd4biB/+tQVx22eN+w+q7Q==",
+      "requires": {
+        "clamp": "1.0.1",
+        "hoist-non-react-statics": "2.5.0",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.1",
+        "react-native-drawer-layout-polyfill": "1.3.2",
+        "react-native-safe-area-view": "0.7.0",
+        "react-native-tab-view": "0.0.74"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
       }
     },
     "react-proxy": {

--- a/example/screens/NavigationViewExample.js
+++ b/example/screens/NavigationViewExample.js
@@ -5,6 +5,8 @@ import {
   View,
   TextInput,
   ScrollView,
+  Switch,
+  Text,
 } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
@@ -18,6 +20,8 @@ class ViewExample extends Component {
       activeInputRef: null,
       nextFocusDisabled: false,
       previousFocusDisabled: false,
+      buttonsDisabled: false,
+      buttonsHidden: false,
     };
   }
 
@@ -43,33 +47,53 @@ class ViewExample extends Component {
     return (
       <View style={styles.container}>
         <KeyboardAwareScrollView
-          contentContainerStyle={styles.contentContainer}>
+          contentContainerStyle={styles.contentContainer}
+        >
+          <View style={styles.switchInput}>
+            <Switch
+              value={this.state.buttonsHidden}
+              onValueChange={() => {
+                this.setState({
+                  buttonsHidden: !this.state.buttonsHidden
+                })
+              }}
+            />
+            <Text style={styles.switchInputText}>
+              Hide arrows
+            </Text>
+          </View>
           <TextInput
             style={styles.textInput}
             ref="1"
             placeholder="Dummy Text Input"
             blurOnSubmit={false}
-            onFocus={this.handleFocus.bind(this, 1)} />
+            onFocus={this.handleFocus.bind(this, 1)}
+          />
           <TextInput
             style={styles.textInput}
             ref="2"
             keyboardType="email-address"
             placeholder="Dummy Text Input Email"
             blurOnSubmit={false}
-            onFocus={this.handleFocus.bind(this, 2)} />
+            onFocus={this.handleFocus.bind(this, 2)}
+          />
           <TextInput
             style={styles.textInput}
             ref="3"
             keyboardType="numeric"
             placeholder="Dummy Text Input Numeric"
             blurOnSubmit={false}
-            onFocus={this.handleFocus.bind(this, 3)} />
+            onFocus={this.handleFocus.bind(this, 3)}
+          />
         </KeyboardAwareScrollView>
         <KeyboardAccessoryNavigation
           nextDisabled={this.state.nextFocusDisabled}
           previousDisabled={this.state.previousFocusDisabled}
+          nextHidden={this.state.buttonsHidden}
+          previousHidden={this.state.buttonsHidden}
           onNext={this.changeInputFocus.bind(this, 1)}
-          onPrevious={this.changeInputFocus.bind(this, -1)}/>
+          onPrevious={this.changeInputFocus.bind(this, -1)}
+        />
       </View>
     );
   }
@@ -93,6 +117,16 @@ const styles = StyleSheet.create({
     padding: 10,
     fontSize: 16,
     marginBottom: 10,
+  },
+  switchInput: {
+    flex: 1,
+    flexDirection: 'row',
+    marginBottom: 10,
+  },
+  switchInputText: {
+    alignSelf: 'center',
+    fontSize: 16,
+    marginLeft: 10,
   },
 });
 

--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -14,7 +14,7 @@ import KeyboardAccessoryView from './KeyboardAccessoryView';
 import Arrow from './components/Arrow';
 
 // Render a prev/hidden arrow button
-const AccessoryArrowButton = ({style, hidden, disabled, onPress ...props}) => {
+const AccessoryArrowButton = ({style, hidden = false, disabled = false, onPress, ...props}) => {
   if (hidden) {
     return null;
   } else {
@@ -40,7 +40,7 @@ AccessoryArrowButton.propTypes = {
   style: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.number
-  ]).isRequired,
+  ]),
   customButton: PropTypes.element,
   tintColor: PropTypes.string.isRequired,
   direction: PropTypes.string.isRequired,
@@ -68,9 +68,9 @@ class KeyboardAccessoryNavigation extends Component {
       onNext,
       onPrevious,
       nextDisabled,
-      prevDisabled,
+      previousDisabled,
       nextHidden,
-      prevHidden,
+      previousHidden,
       style,
       accessoryStyle,
       nextButtonStyle,
@@ -86,14 +86,14 @@ class KeyboardAccessoryNavigation extends Component {
     return (
       <KeyboardAccessoryView {...(style ? { style } : {})} alwaysVisible={alwaysVisible}>
         <View style={[styles.accessoryContainer, accessoryStyle]}>
-          {!nextHidden && !prevHidden && (
+          {!nextHidden && !previousHidden && (
             <View style={styles.leftContainer}>
               <AccessoryArrowButton
                 style={[styles.previousButton, previousButtonStyle]}
-                hidden={prevHidden}
-                disabled={prevDisabled}
-                direction={prevButtonDirection}
-                customButton={prevButton}
+                hidden={previousHidden}
+                disabled={previousDisabled}
+                direction={previousButtonDirection}
+                customButton={previousButton}
                 tintColor={tintColor}
                 onPress={onPrevious}
               />
@@ -108,21 +108,21 @@ class KeyboardAccessoryNavigation extends Component {
               />
             </View>
           )}
-          { (infoMessage || infoContainer) &&
+          {(infoMessage || infoContainer) && (
             <View style={styles.infoContainer}>
-              { infoContainer ? infoContainer : (
+              {infoContainer ? infoContainer : (
                 <Text style={[infoMessageStyle, {
                   color: tintColor,
                 }]}>
-                  { infoMessage }
+                  {infoMessage}
                 </Text>
               )}
             </View>
-          }
+          )}
           <TouchableOpacity
             style={[styles.doneButton, doneButtonStyle]}
             onPress={this.handleDoneButton.bind(this)} >
-            { doneButton ? doneButton : (
+            {doneButton ? doneButton : (
               <Text style={[ styles.doneButtonText, doneButtonTitleStyle, {
                 color: tintColor,
               }]}>
@@ -147,10 +147,10 @@ KeyboardAccessoryNavigation.propTypes = {
   onPrevious: PropTypes.func,
   onDone: PropTypes.func,
   nextDisabled: PropTypes.bool,
-  prevDisabled: PropTypes.bool,
+  previousDisabled: PropTypes.bool,
   doneDisabled: PropTypes.bool,
   nextHidden: PropTypes.bool,
-  prevHidden: PropTypes.bool,
+  previousHidden: PropTypes.bool,
   alwaysVisible: PropTypes.bool,
   tintColor: PropTypes.string,
   style: PropTypes.oneOfType([
@@ -191,7 +191,7 @@ KeyboardAccessoryNavigation.defaultProps = {
   nextDisabled: false,
   previousDisabled: false,
   nextHidden: false,
-  prevHidden: false,
+  previousHidden: false,
   nextButtonDirection: 'down',
   previousButtonDirection: 'up',
   alwaysVisible: false,

--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -82,10 +82,22 @@ class KeyboardAccessoryNavigation extends Component {
       alwaysVisible,
     } = this.props;
 
+    // Are both arrows hidden?
+    const arrowsHidden = nextHidden && previousHidden;
+
+    // Is there an info message/container?
+    const noInfo = !infoMessage && !infoContainer;
+
+    const accessoryContainerStyle = [
+      styles.accessoryContainer,
+      arrowsHidden && noInfo ? styles.accessoryContainerReverse : null,
+      accessoryStyle,
+    ]
+
     return (
       <KeyboardAccessoryView {...(style ? { style } : {})} alwaysVisible={alwaysVisible}>
-        <View style={[styles.accessoryContainer, accessoryStyle]}>
-          {!nextHidden && !previousHidden && (
+        <View style={accessoryContainerStyle}>
+          {!arrowsHidden && (
             <View style={styles.leftContainer}>
               <AccessoryArrowButton
                 style={[styles.previousButton, previousButtonStyle]}
@@ -120,7 +132,8 @@ class KeyboardAccessoryNavigation extends Component {
           )}
           <TouchableOpacity
             style={[styles.doneButton, doneButtonStyle]}
-            onPress={this.handleDoneButton.bind(this)} >
+            onPress={this.handleDoneButton.bind(this)}
+          >
             {doneButton ? doneButton : (
               <Text style={[ styles.doneButtonText, doneButtonTitleStyle, {
                 color: tintColor,
@@ -204,6 +217,9 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingLeft: 15,
     paddingRight: 15,
+  },
+  accessoryContainerReverse: {
+    flexDirection: 'row-reverse',
   },
   leftContainer: {
     flexDirection: 'row',

--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -13,6 +13,42 @@ import {
 import KeyboardAccessoryView from './KeyboardAccessoryView';
 import Arrow from './components/Arrow';
 
+// Render a prev/hidden arrow button
+const AccessoryArrowButton = ({style, hidden, disabled, onPress ...props}) => {
+  if (hidden) {
+    return null;
+  } else {
+    return (
+      <TouchableOpacity
+        disabled={disabled}
+        style={style}
+        onPress={onPress}
+      >
+        {props.customButton ? props.customButton : (
+          <Arrow
+            direction={props.direction}
+            disabled={disabled}
+            tintColor={props.tintColor}
+          />
+        )}
+      </TouchableOpacity>
+    );
+  }
+}
+
+AccessoryArrowButton.propTypes = {
+  style: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number
+  ]).isRequired,
+  customButton: PropTypes.element,
+  tintColor: PropTypes.string.isRequired,
+  direction: PropTypes.string.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired,
+}
+
 class KeyboardAccessoryNavigation extends Component {
 
   handleDoneButton() {
@@ -32,7 +68,9 @@ class KeyboardAccessoryNavigation extends Component {
       onNext,
       onPrevious,
       nextDisabled,
-      previousDisabled,
+      prevDisabled,
+      nextHidden,
+      prevHidden,
       style,
       accessoryStyle,
       nextButtonStyle,
@@ -48,30 +86,28 @@ class KeyboardAccessoryNavigation extends Component {
     return (
       <KeyboardAccessoryView {...(style ? { style } : {})} alwaysVisible={alwaysVisible}>
         <View style={[styles.accessoryContainer, accessoryStyle]}>
-          <View style={styles.leftContainer}>
-            <TouchableOpacity
-              disabled={previousDisabled}
-              style={[styles.previousButton, previousButtonStyle]}
-              onPress={onPrevious} >
-              { previousButton ? previousButton : (
-                <Arrow
-                  direction={previousButtonDirection}
-                  disabled={previousDisabled}
-                  tintColor={ tintColor } />
-              )}
-            </TouchableOpacity>
-            <TouchableOpacity
-              disabled={nextDisabled}
-              {...(style ? { style: nextButtonStyle } : {})}
-              onPress={onNext} >
-              { nextButton ? nextButton : (
-                <Arrow
-                  direction={nextButtonDirection}
-                  disabled={nextDisabled}
-                  tintColor={ tintColor } />
-              )}
-            </TouchableOpacity>
-          </View>
+          {!nextHidden && !prevHidden && (
+            <View style={styles.leftContainer}>
+              <AccessoryArrowButton
+                style={[styles.previousButton, previousButtonStyle]}
+                hidden={prevHidden}
+                disabled={prevDisabled}
+                direction={prevButtonDirection}
+                customButton={prevButton}
+                tintColor={tintColor}
+                onPress={onPrevious}
+              />
+              <AccessoryArrowButton
+                style={{...(style ? { style: nextButtonStyle } : {})}}
+                hidden={nextHidden}
+                disabled={nextDisabled}
+                direction={nextButtonDirection}
+                customButton={nextButton}
+                tintColor={tintColor}
+                onPress={onNext}
+              />
+            </View>
+          )}
           { (infoMessage || infoContainer) &&
             <View style={styles.infoContainer}>
               { infoContainer ? infoContainer : (
@@ -111,10 +147,11 @@ KeyboardAccessoryNavigation.propTypes = {
   onPrevious: PropTypes.func,
   onDone: PropTypes.func,
   nextDisabled: PropTypes.bool,
-  previousDisabled: PropTypes.bool,
+  prevDisabled: PropTypes.bool,
   doneDisabled: PropTypes.bool,
+  nextHidden: PropTypes.bool,
+  prevHidden: PropTypes.bool,
   alwaysVisible: PropTypes.bool,
-
   tintColor: PropTypes.string,
   style: PropTypes.oneOfType([
     PropTypes.object,
@@ -153,6 +190,8 @@ KeyboardAccessoryNavigation.defaultProps = {
   tintColor: '#007AFF',
   nextDisabled: false,
   previousDisabled: false,
+  nextHidden: false,
+  prevHidden: false,
   nextButtonDirection: 'down',
   previousButtonDirection: 'up',
   alwaysVisible: false,

--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -50,7 +50,6 @@ AccessoryArrowButton.propTypes = {
 }
 
 class KeyboardAccessoryNavigation extends Component {
-
   handleDoneButton() {
     this.props.onDone && this.props.onDone();
     Keyboard.dismiss();

--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -214,7 +214,7 @@ const styles = StyleSheet.create({
   },
   doneButtonText: {
     fontWeight: 'bold'
-  }
+  },
 })
 
 export default KeyboardAccessoryNavigation;


### PR DESCRIPTION
Please do not merge. 

There's still some more work to be done here and I haven't actually tested the code because I can't get the example to link to the package. Is the example working?

Changes:
- Adds `nextHidden` boolean prop to hide next button (defaults to `false`)
- Adds `prevHidden` boolean prop to hide prev button (also defaults to `false`)
- Renames `previousDisabled` prop to `prevDisabled` (to follow the rest of the props)

Connect https://github.com/ardaogulcan/react-native-keyboard-accessory/issues/5.