### PR TITLE
fix Android release build

### DIFF
--- a/lib/KeyboardAccessoryNavigation.js
+++ b/lib/KeyboardAccessoryNavigation.js
@@ -7,6 +7,7 @@ import {
   Text,
   TouchableOpacity,
   Keyboard,
+  ViewPropTypes,
 } from 'react-native';
 
 import KeyboardAccessoryView from './KeyboardAccessoryView';
@@ -130,12 +131,12 @@ KeyboardAccessoryNavigation.propTypes = {
   nextHidden: PropTypes.bool,
   previousHidden: PropTypes.bool,
   tintColor: PropTypes.string,
-  accessoryStyle: View.propTypes.style,
-  previousButtonStyle: View.propTypes.style,
-  nextButtonStyle: View.propTypes.style,
-  doneButtonStyle: View.propTypes.style,
-  doneButtonTitleStyle: View.propTypes.style,
-  infoMessageStyle: View.propTypes.style,
+  accessoryStyle: ViewPropTypes.style,
+  previousButtonStyle: ViewPropTypes.style,
+  nextButtonStyle: ViewPropTypes.style,
+  doneButtonStyle: ViewPropTypes.style,
+  doneButtonTitleStyle: ViewPropTypes.style,
+  infoMessageStyle: ViewPropTypes.style,
   nextButtonDirection: PropTypes.oneOf(['up', 'down', 'left', 'right']),
   previousButtonDirection: PropTypes.oneOf(['up', 'down', 'left', 'right']),
 }

--- a/lib/KeyboardAccessoryView.js
+++ b/lib/KeyboardAccessoryView.js
@@ -7,6 +7,7 @@ import {
   LayoutAnimation,
   Platform,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 
 const accessoryAnimation = (duration, easing, animationConfig = null) => {
@@ -158,7 +159,7 @@ class KeyboardAccessoryView extends Component {
 }
 
 KeyboardAccessoryView.propTypes = {
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   animateOn: PropTypes.oneOf(['ios', 'android', 'all', 'none']),
   animationConfig: PropTypes.oneOfType([
     PropTypes.object,


### PR DESCRIPTION
This was causing a crash when opening a release (production) build.

`adb logcat`
```
04-10 13:24:56.417 12009 12036 E ReactNativeJS: undefined is not an object (evaluating 'l.View.propTypes.style')
```

https://github.com/facebook/react-native/commit/1129c6096d2f2b86e7b26f25f51992d5c259a744
28 Mar 2017
```
    // ReactNative `View.propTypes` have been deprecated in favor of
    // `ViewPropTypes`. In their place a temporary getter has been added with a
    // deprecated warning message. Avoid triggering that warning here by using
    // temporary workaround, __propTypesSecretDontUseThesePlease.
```

See also:
https://github.com/facebook/react-native/issues/16352