### PR TITLE
Update KeyboardAccessoryView.js

### DIFF
--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -147,9 +147,8 @@ class KeyboardAccessoryView extends Component {
       inSafeAreaView,
       safeAreaBumper,
     } = this.props;
-
     return (
-      <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight : 0) }}>
+      <View style={{ height: (isKeyboardVisible || alwaysVisible ? accessoryHeight + keyboardHeight  : 0) }}>
         <View style={[
           styles.accessory,
           !hideBorder && styles.accessoryBorder,


### PR DESCRIPTION
when keyboard show the out view should set real height

## keyboard not show
`
View 
        TextInput(flex:1)
         KeyboardView()
                         View (height: 64)
`

## KeyboardShow
`
View 
        TextInput(flex:1)
         KeyboardView()
                         View(height: 64, but parent view is 'absolute', so textinput is full height ...)
`