### PR TITLE
Optionally allow children to accept a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Use it inside your `render()` function:
 
 ***Important:*** KeyboardAccessoryView should be positioned inside the Root Element which is covering the screen, mostly the top most view styled as ``{ flex: 1 }``.
 
+#### Render Prop
+
+Alternatively, you can also pass a function as the `children` prop of the component. This allows you to access an `isKeyboardVisible` prop which is useful to render things conditionally based on the visibility of the keyboard:
+
+```jsx
+<KeyboardAccessoryView>
+  {({ isKeyboardVisible }) => {
+    return (
+      <>
+        <Text>Always visible</Text>
+        {!isKeyboardVisible ? (
+          <Text>Hidden when keyboard is visible</Text>
+        ) : null}
+      </>
+    );
+  }}
+</KeyboardAccessoryView>
+```
+
 ### Keyboard Accessory Navigation
 Import ``react-native-keyboard-accessory``
 

--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -151,10 +151,12 @@ class KeyboardAccessoryView extends Component {
       inSafeAreaView,
       safeAreaBumper,
       avoidKeyboard,
+      children,
     } = this.props;
 
     const visibleHeight = accessoryHeight + (avoidKeyboard ? keyboardHeight : 0);
     const applySafeArea = isSafeAreaSupported && inSafeAreaView;
+    const isChildRenderProp = typeof children === "function";
 
     return (
       <View style={{ height: (isKeyboardVisible || alwaysVisible ? visibleHeight  : 0) }}>
@@ -169,7 +171,9 @@ class KeyboardAccessoryView extends Component {
           }
         ]}>
           <View onLayout={this.handleChildrenLayout}>
-            { this.props.children }
+            { isChildRenderProp
+               ? children({ isKeyboardVisible })
+               : children }
           </View>
         </View>
       </View>


### PR DESCRIPTION
This PR is a simple change that enables you to pass a [render prop](https://reactjs.org/docs/render-props.html) to `KeyboardAccessoryView`. 

I've found in multiple applications that it's really convenient to be able to render different views depending on whether the keyboard is visible or not. By using a render prop it allows us a really convenient way to do this, without having to subscribe to any events.

e.g:

```js
<KeyboardAccessoryView alwaysVisible>
  {({isKeyboardVisible}) => {
    return (
      <>
        <Text>My Keyboard Accessory</Text>
        {!isKeyboardVisible ? (
          <Text>Hidden when keyboard is visible</Text>
        ) : null}
      </>
    )
  }}
</KeyboardAccessoryView>
```

Since this is optional, it is a non-breaking change.