### PR TITLE
Add a TypeScript module definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,68 @@
+import { ViewStyle, LayoutAnimationConfig, StyleProp } from "react-native";
+import { ReactNode } from "react";
+
+export type KeyboardAccessoryViewRenderProp = ({
+  isKeyboardVisible,
+}: {
+  isKeyboardVisible: boolean;
+}) => ReactNode;
+
+export interface KeyboardAccessoryViewProps {
+  style?: StyleProp<ViewStyle>;
+  animateOn?: "ios" | "android" | "all" | "none";
+  animationConfig?: (() => LayoutAnimationConfig) | LayoutAnimationConfig;
+  alwaysVisible?: boolean;
+  bumperHeight?: number;
+  visibleOpacity?: number;
+  onKeyboardShowDelay?: boolean | number;
+  hiddenOpacity?: number;
+  hideBorder?: boolean;
+  inSafeAreaView?: boolean;
+  androidAdjustResize?: boolean;
+  avoidKeyboard?: boolean;
+  children: KeyboardAccessoryViewRenderProp | ReactNode;
+}
+
+export declare const KeyboardAccessoryView: React.ComponentType<KeyboardAccessoryViewProps>;
+
+export type KeyboardAccessoryNavigationArrowDirection =
+  | "down"
+  | "up"
+  | "right"
+  | "left";
+
+export interface KeyboardAccessoryNavigationProps
+  extends KeyboardAccessoryViewProps {
+  doneButtonTitle?: string;
+  tintColor?: string;
+  doneButton?: ReactNode;
+  nextButton?: ReactNode;
+  previousButton?: ReactNode;
+  infoContainer?: ReactNode;
+  doneDisabled?: boolean;
+  nextDisabled?: boolean;
+  previousDisabled?: boolean;
+  doneHidden?: boolean;
+  nextHidden?: boolean;
+  previousHidden?: boolean;
+  accessoryStyle?: StyleProp<ViewStyle>;
+  doneButtonStyle?: StyleProp<ViewStyle>;
+  doneButtonTitleStyle?: StyleProp<ViewStyle>;
+  infoMessageStyle?: StyleProp<ViewStyle>;
+  previousButtonStyle?: StyleProp<ViewStyle>;
+  nextButtonStyle?: StyleProp<ViewStyle>;
+  nextButtonDirection?: KeyboardAccessoryNavigationArrowDirection;
+  previousButtonDirection?: KeyboardAccessoryNavigationArrowDirection;
+  onDone?: () => void;
+  onNext?: () => void;
+  onPrevious?: () => void;
+}
+
+export declare const KeyboardAccessoryNavigation: React.ComponentType<KeyboardAccessoryNavigationProps>;
+
+export interface KeyboardAwareTabBarComponentProps {
+  TabBarComponent: React.ComponentType<any>;
+  [x: string]: any;
+}
+
+export declare const KeyboardAwareTabBarComponent: React.ComponentType<KeyboardAwareTabBarComponentProps>;


### PR DESCRIPTION
Adds a TS module definition based on the documentation and prop types.

The type for `KeyboardAwareTabBarComponent` could be improved (the pass-through props will be untyped, essentially) but it should not cause any problems.

Perhaps the project will be written in TS one day, but this is a good part-way solution 😃 

You'll need to make sure `index.d.ts` is included in the nom package when publishing.