### PR TITLE
Fix Spacing Issue (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ example/react-native-keyboard-accessory
 
 build
 .vscode
+.idea

--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -153,8 +153,11 @@ class KeyboardAccessoryView extends Component {
       children,
     } = this.props;
 
-    const visibleHeight = accessoryHeight + (avoidKeyboard ? keyboardHeight : 0);
     const applySafeArea = isSafeAreaSupported && inSafeAreaView;
+    const visibleHeight =
+      accessoryHeight
+      + (avoidKeyboard ? keyboardHeight : 0)
+      - (isKeyboardVisible ? bumperHeight + (applySafeArea ? 20 : 0) : 0);
     const isChildRenderProp = typeof children === "function";
 
     return (


### PR DESCRIPTION
I'm having a spacing issue when `avoidKeyboard` is true. I believe that the current code isn't taking into account the safe area when calculating final height. I believe this also fixes #44 in cases where `avoidKeyboard` is false.