### PR TITLE
fix KeyboardAccessoryNavigationProps typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export type KeyboardAccessoryViewRenderProp = ({
   isKeyboardVisible: boolean;
 }) => ReactNode;
 
-export interface KeyboardAccessoryViewProps {
+export interface KeyboardAccessoryProps {
   style?: StyleProp<ViewStyle>;
   animateOn?: "ios" | "android" | "all" | "none";
   animationConfig?: (() => LayoutAnimationConfig) | LayoutAnimationConfig;
@@ -20,6 +20,10 @@ export interface KeyboardAccessoryViewProps {
   inSafeAreaView?: boolean;
   androidAdjustResize?: boolean;
   avoidKeyboard?: boolean;
+}
+
+export interface KeyboardAccessoryViewProps 
+  extends KeyboardAccessoryProps {
   children: KeyboardAccessoryViewRenderProp | ReactNode;
 }
 
@@ -32,7 +36,7 @@ export type KeyboardAccessoryNavigationArrowDirection =
   | "left";
 
 export interface KeyboardAccessoryNavigationProps
-  extends KeyboardAccessoryViewProps {
+  extends KeyboardAccessoryProps {
   doneButtonTitle?: string;
   tintColor?: string;
   doneButton?: ReactNode;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export type KeyboardAccessoryViewRenderProp = ({
   isKeyboardVisible: boolean;
 }) => ReactNode;
 
-export interface KeyboardAccessoryProps {
+interface KeyboardAccessoryProps {
   style?: StyleProp<ViewStyle>;
   animateOn?: "ios" | "android" | "all" | "none";
   animationConfig?: (() => LayoutAnimationConfig) | LayoutAnimationConfig;


### PR DESCRIPTION
Based on the actual index.d.ts, whenever we want to use the `KeyboardAccessoryNavigation` component, we are forced to create empty children component because `KeyboardAccessoryNavigationProps` extends `KeyboardAccessoryViewProps` that has a `children` props as required.

before PR changes:
<img width="516" alt="Screenshot 2020-10-28 at 16 11 22" src="https://user-images.githubusercontent.com/1201561/97455594-503d7500-1938-11eb-99a9-84f17fcb92a4.png">

after PR changes:
![image](https://user-images.githubusercontent.com/1201561/97455724-72cf8e00-1938-11eb-8d8e-064dc6e8f4d6.png)
