### PR TITLE
Fix cut off next button arrow

### DIFF
--- a/src/components/Arrow/index.js
+++ b/src/components/Arrow/index.js
@@ -49,6 +49,7 @@ const styles = StyleSheet.create({
   arrowImage: {
     width: 21,
     height: 12,
+    resizeMode: 'contain',
   }
 });
 


### PR DESCRIPTION
Next button always had ~1px cut off on it's right (rotation 'down') side.