### PR TITLE
Fix issue where multiline text inputs are not able to grow

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ And set `androidAdjustResize` to `true`. For example,
 | `alwaysVisible` | `boolean` | `false` | When set to `true` Accessory View will be always visible at the bottom of the screen. Good for sticky `TextInput`'s |
 | `bumperHeight` | `number` | 15 | Bumper height to prevent visual glitches if animation couldn't keep up with the keyboard animation. |
 | `visibleOpacity` | `number` | 1 | Opacity of the Accessory when it is visible. *Note:* Opacity is used for hiding the accessory to prevent render delays. |
+| `heightProperty` | `enum:string` | `height` | Control how the component manages its height. The component listens for children changes and automatically adjusts its height, so `height` is usually sufficient. For use with a multiline, autogrowing `TextInput`, `minHeight` is recommended. Values: `['height', 'minHeight']` |
 | `hiddenOpacity` | `number` | 0 | Opacity of the Accessory when it is hidden. |
 | `hideBorder` | `boolean` | false | Set true if you want to hide top border of the Accessory |
 | `inSafeAreaView` | `boolean` | false | Set true if you want to adapt SafeAreaView on iPhone X |

--- a/example/screens/ViewExample.js
+++ b/example/screens/ViewExample.js
@@ -16,7 +16,7 @@ class ViewExample extends Component {
             }}
           />
         </ScrollView>
-        <KeyboardAccessoryView alwaysVisible={true} androidAdjustResize>
+        <KeyboardAccessoryView heightProperty="minHeight" alwaysVisible={true} androidAdjustResize>
           {({ isKeyboardVisible }) => (
             <View style={styles.textInputView}>
               <TextInput

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ interface KeyboardAccessoryProps {
   bumperHeight?: number;
   visibleOpacity?: number;
   onKeyboardShowDelay?: boolean | number;
+  heightProperty?: 'height' | 'minHeight';
   hiddenOpacity?: number;
   hideBorder?: boolean;
   inSafeAreaView?: boolean;

--- a/src/KeyboardAccessoryView.js
+++ b/src/KeyboardAccessoryView.js
@@ -146,6 +146,7 @@ class KeyboardAccessoryView extends Component {
       visibleOpacity,
       hiddenOpacity,
       hideBorder,
+      heightProperty,
       style,
       inSafeAreaView,
       safeAreaBumper,
@@ -158,7 +159,7 @@ class KeyboardAccessoryView extends Component {
     const isChildRenderProp = typeof children === "function";
 
     return (
-      <View style={{ height: (isKeyboardVisible || alwaysVisible ? visibleHeight  : 0) }}>
+      <View style={{ [heightProperty]: (isKeyboardVisible || alwaysVisible ? visibleHeight  : 0) }}>
         <View style={[
           styles.accessory,
           !hideBorder && styles.accessoryBorder,
@@ -166,7 +167,7 @@ class KeyboardAccessoryView extends Component {
           {
             opacity: (isKeyboardVisible || alwaysVisible ? visibleOpacity : hiddenOpacity),
             bottom: keyboardHeight - bumperHeight - (applySafeArea ? 20 : 0),
-            height: accessoryHeight + bumperHeight + (applySafeArea ? (!isKeyboardVisible ? 20 : -10) : 0),
+            [heightProperty]: accessoryHeight + bumperHeight + (applySafeArea ? (!isKeyboardVisible ? 20 : -10) : 0),
           }
         ]}>
           <View onLayout={this.handleChildrenLayout}>
@@ -186,6 +187,7 @@ KeyboardAccessoryView.propTypes = {
   animationConfig: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   bumperHeight: PropTypes.number,
   visibleOpacity: PropTypes.number,
+  heightProperty: PropTypes.oneOf(["height", "minHeight"]),
   hiddenOpacity: PropTypes.number,
   onKeyboardShowDelay: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   androidAdjustResize: PropTypes.bool,
@@ -199,6 +201,7 @@ KeyboardAccessoryView.defaultProps = {
   animateOn: 'ios',
   bumperHeight: 15,
   visibleOpacity: 1,
+  heightProperty: 'height',
   hiddenOpacity: 0,
   androidAdjustResize: false,
   alwaysVisible: false,


### PR DESCRIPTION
React Native's `TextInput` can autogrow when the `multiline` prop is passed. However, if any parent element has a fixed `height`, the input will not grow, and any parent elements will also not have `onLayout` triggered.

Due to the above and since this library controls the height with a fixed `height` and adjusts to changing heights by listening with `onLayout`, the height never adjusts when a multiline input is used inside an accessory. There were ways to work around this with the text input by using `onContentSizeChange` to manually set the text input height, but `onContentSizeChange` is notoriously buggy (doesn't always fire or has incorrect height) and not able to provide proper autogrow behavior (I spent a couple days going down that path).

This PR adds a new prop to `KeyboardAccessoryView`: `heightProperty`. If set to `minHeight`, then this library uses `minHeight` instead of `height` to control the sizing of the accessory.

<details>
<summary>🎥 Before</summary>

https://user-images.githubusercontent.com/1691324/133459077-ffa7d488-325b-4336-9bb2-0123c322d73e.mov

</details>

<details>
<summary>🎥 After (heightProperty="minHeight")</summary>

https://user-images.githubusercontent.com/1691324/133459772-18cb9512-a445-418b-af7d-b9e425f8ba77.mov

</details>


And here is my code that was used for the above examples:

```jsx
<KeyboardAccessoryView
  alwaysVisible={true}
  avoidKeyboard={true}
  hideBorder={true}
  heightProperty="minHeight"
>
  <View style={styles.container}>
    <TextInput
      onChangeText={(text) => setMessage(text)}
      style={styles.input}
      multiline={true}
      value={message}
    />
    <SendButton />
  </View>
</KeyboardAccessoryView>

// some irrelevant styles omitted
const styles = StyleSheet.create({
  container: {
    flexGrow: 1,
    minHeight: 64,
  },
  input: {
    flexGrow: 1,
  },
};
```

This change can also be tried out by installing it in `package.json` (I committed the build directory in this other branch so this would work):

```js
"react-native-keyboard-accessory": "stevehanson/react-native-keyboard-accessory#expanding-height",
```