### PR TITLE
Change Text style props to the correct type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { ViewStyle, LayoutAnimationConfig, StyleProp, Insets } from "react-native";
+import { ViewStyle, LayoutAnimationConfig, StyleProp, Insets, TextStyle } from "react-native";
 import { ReactNode } from "react";
 
 export type KeyboardAccessoryViewRenderProp = ({
@@ -52,8 +52,8 @@ export interface KeyboardAccessoryNavigationProps
   previousHidden?: boolean;
   accessoryStyle?: StyleProp<ViewStyle>;
   doneButtonStyle?: StyleProp<ViewStyle>;
-  doneButtonTitleStyle?: StyleProp<ViewStyle>;
-  infoMessageStyle?: StyleProp<ViewStyle>;
+  doneButtonTitleStyle?: StyleProp<TextStyle>;
+  infoMessageStyle?: StyleProp<TextStyle>;
   doneButtonHitslop?: number | Insets;
   previousButtonStyle?: StyleProp<ViewStyle>;
   nextButtonStyle?: StyleProp<ViewStyle>;


### PR DESCRIPTION
Both [`doneButtonTitleStyle`](https://github.com/ardaogulcan/react-native-keyboard-accessory/blob/master/src/KeyboardAccessoryNavigation.js#L107) and [`infoMessageStyle`](https://github.com/ardaogulcan/react-native-keyboard-accessory/blob/master/src/KeyboardAccessoryNavigation.js#L92) are style props to `Text` components, therefore their type should be `StyleProp<TextStyle>`. This fixes a typescript bug that would disallow you from setting Text-specific styles on these properties like `fontSize` and `fontWeight` to name a few.

> [!NOTE]  
> I noticed when going through the code that you added `infoContainer`, `infoMessage` and `infoMessageStyle`, but only the latter is defined in the types. I tried these out and they seem to work as inteded, if you want I can add these props to the types and README so they are discoverable to future users.
